### PR TITLE
feat(session): add optional logging and secure token handling

### DIFF
--- a/core/session/config.go
+++ b/core/session/config.go
@@ -1,6 +1,8 @@
 package session
 
 import (
+	"io"
+	"log/slog"
 	"time"
 )
 
@@ -9,12 +11,16 @@ type Config struct {
 	// Timing
 	TTL           time.Duration // Session time-to-live (idle timeout)
 	TouchInterval time.Duration // Min time between activity updates (0 = disabled)
+
+	// Logging
+	Logger *slog.Logger // Logger for internal operations (nil = no-op logger)
 }
 
 func defaultConfig() *Config {
 	return &Config{
 		TTL:           24 * time.Hour,
 		TouchInterval: 5 * time.Minute,
+		Logger:        slog.New(slog.NewTextHandler(io.Discard, nil)), // No-op logger by default
 	}
 }
 
@@ -34,5 +40,15 @@ func WithTTL(ttl time.Duration) Option {
 func WithTouchInterval(interval time.Duration) Option {
 	return func(c *Config) {
 		c.TouchInterval = interval
+	}
+}
+
+// WithLogger sets the logger for internal session operations.
+// If nil, a no-op logger will be used.
+func WithLogger(logger *slog.Logger) Option {
+	return func(c *Config) {
+		if logger != nil {
+			c.Logger = logger
+		}
 	}
 }

--- a/core/session/session.go
+++ b/core/session/session.go
@@ -12,7 +12,8 @@ import (
 // Supports both anonymous and authenticated states.
 type Session[Data any] struct {
 	ID        uuid.UUID `json:"id"`         // Stable session identifier
-	Token     string    `json:"token"`      // Rotatable secure token
+	Token     string    `json:"-"`          // Raw secure token (not exposed in JSON)
+	TokenHash string    `json:"-"`          // SHA-256 hash of the secure token (not exposed)
 	DeviceID  uuid.UUID `json:"device_id"`  // Persistent device/browser ID
 	UserID    uuid.UUID `json:"user_id"`    // User ID (uuid.Nil for anonymous)
 	Data      Data      `json:"data"`       // Application-defined data
@@ -35,9 +36,9 @@ func (s Session[Data]) IsExpired() bool {
 // Implementations can use cookies, Redis, databases, etc.
 // All methods use value semantics to ensure thread safety.
 type Store[Data any] interface {
-	// Get retrieves a session by its token.
+	// Get retrieves a session by its token hash.
 	// Returns a copy of the session to ensure thread safety.
-	Get(ctx context.Context, token string) (Session[Data], error)
+	Get(ctx context.Context, tokenHash string) (Session[Data], error)
 
 	// Store saves or updates a session.
 	// Takes a copy of the session to ensure thread safety.


### PR DESCRIPTION
## Summary

Enhances the core/session package with optional logging functionality and secure token handling to improve debugging capabilities and security while maintaining backward compatibility.

### Changes

- **Optional logging integration**: Add configurable `slog.Logger` with no-op default, following patterns from other packages like core/queue
- **Secure token storage**: Implement SHA-256 token hashing for persistent storage while keeping raw tokens for transport layer
- **Enhanced error visibility**: Log session lifecycle events (creation, authentication, expiration) and silent errors that cannot be exposed to callers
- **Test updates**: Update all tests to work with new token hashing system and verify logging integration

### Security Improvements

- Session tokens are now hashed with SHA-256 before storage, preventing token exposure in persistent stores
- Raw tokens are only used by the transport layer (cookies, headers) and never stored
- Store interface now uses token hashes instead of raw tokens for lookups

### Breaking Changes

- `Store[Data].Get()` method signature changed from `Get(ctx, token)` to `Get(ctx, tokenHash)`
- `Session[Data].Token` field is now excluded from JSON serialization (`json:"-"`)
- New `Session[Data].TokenHash` field added for internal use