### PR TITLE
refactor(server): improve lifecycle management and autocert concurrency

### DIFF
--- a/core/letsencrypt/errors.go
+++ b/core/letsencrypt/errors.go
@@ -20,4 +20,7 @@ var (
 
 	// ErrCertDirRequired is returned when certificate directory is not provided in config.
 	ErrCertDirRequired = errors.New("certificate directory is required")
+
+	// ErrDeleteFailed is returned when certificate deletion fails.
+	ErrDeleteFailed = errors.New("certificate deletion failed")
 )

--- a/core/letsencrypt/storage.go
+++ b/core/letsencrypt/storage.go
@@ -8,6 +8,13 @@ import (
 	"strings"
 )
 
+const (
+	// acmeAccountKeyMarker is used by autocert to mark account key files.
+	acmeAccountKeyMarker = "+"
+	// acmeMetadataMarker is used by autocert to mark metadata files.
+	acmeMetadataMarker = "_"
+)
+
 // Storage provides low-level certificate file operations.
 type Storage struct {
 	dir string
@@ -34,7 +41,7 @@ func (s *Storage) List() ([]string, error) {
 		if !entry.IsDir() {
 			// Exclude autocert metadata files (contain + or _)
 			name := entry.Name()
-			if name != "" && !strings.Contains(name, "+") && !strings.Contains(name, "_") {
+			if name != "" && !strings.Contains(name, acmeAccountKeyMarker) && !strings.Contains(name, acmeMetadataMarker) {
 				domains = append(domains, name)
 			}
 		}

--- a/core/server/autocert_config_test.go
+++ b/core/server/autocert_config_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dmitrymomot/foundation/core/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/foundation/core/server"
 )
 
 func TestNewAutoCertFromConfig(t *testing.T) {

--- a/core/server/config.go
+++ b/core/server/config.go
@@ -41,7 +41,7 @@ func NewFromConfig(cfg Config, opts ...Option) (*Server, error) {
 		return nil, ErrMissingAddress
 	}
 
-	configOpts := make([]Option, 0)
+	var configOpts []Option
 
 	if cfg.ReadTimeout > 0 {
 		configOpts = append(configOpts, WithReadTimeout(cfg.ReadTimeout))

--- a/core/server/config_test.go
+++ b/core/server/config_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/dmitrymomot/foundation/core/server"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dmitrymomot/foundation/core/server"
 )
 
 func TestNewFromConfig(t *testing.T) {

--- a/core/server/constants.go
+++ b/core/server/constants.go
@@ -3,9 +3,10 @@ package server
 import "time"
 
 const (
-	DefaultReadTimeout     = 15 * time.Second
-	DefaultWriteTimeout    = 15 * time.Second
-	DefaultIdleTimeout     = 60 * time.Second
-	DefaultShutdownTimeout = 30 * time.Second
-	DefaultMaxHeaderBytes  = 1 << 20 // 1 MB
+	DefaultReadTimeout         = 15 * time.Second
+	DefaultWriteTimeout        = 15 * time.Second
+	DefaultIdleTimeout         = 60 * time.Second
+	DefaultShutdownTimeout     = 30 * time.Second
+	DefaultMaxHeaderBytes      = 1 << 20 // 1 MB
+	DefaultDomainLookupTimeout = 10 * time.Second
 )

--- a/core/server/options.go
+++ b/core/server/options.go
@@ -71,3 +71,12 @@ func WithMaxHeaderBytes(max int) Option {
 		s.maxHeaderBytes = max
 	}
 }
+
+// WithServerShutdownTimeout sets the maximum time to wait for graceful shutdown of AutoCertServer.
+func WithServerShutdownTimeout(timeout time.Duration) AutoCertOption {
+	return func(s *AutoCertServer) {
+		if timeout > 0 {
+			s.shutdownTimeout = timeout
+		}
+	}
+}

--- a/core/server/templates.go
+++ b/core/server/templates.go
@@ -1,0 +1,199 @@
+package server
+
+import (
+	"html/template"
+	"strings"
+)
+
+// Precompiled templates for status pages.
+// These are parsed once at package initialization for efficiency.
+var (
+	provisioningTemplate = template.Must(template.New("provisioning").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="refresh" content="10">
+    <title>Securing Connection</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 0;
+            padding: 20px;
+        }
+        .container {
+            background: white;
+            border-radius: 12px;
+            box-shadow: 0 20px 60px rgba(0,0,0,0.15);
+            padding: 40px;
+            max-width: 500px;
+            width: 100%;
+            text-align: center;
+        }
+        h1 { color: #333; margin: 0 0 20px; font-size: 28px; }
+        .lock-icon { font-size: 48px; margin-bottom: 20px; }
+        .domain { color: #667eea; font-weight: 600; font-size: 18px; }
+        p { color: #666; line-height: 1.6; margin: 15px 0; }
+        .progress {
+            width: 100%;
+            height: 6px;
+            background: #f0f0f0;
+            border-radius: 3px;
+            overflow: hidden;
+            margin: 30px 0;
+        }
+        .progress-bar {
+            height: 100%;
+            background: linear-gradient(90deg, #667eea, #764ba2);
+            animation: progress 2s ease-in-out infinite;
+        }
+        @keyframes progress {
+            0% { transform: translateX(-100%); }
+            50% { transform: translateX(0); }
+            100% { transform: translateX(100%); }
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <div class="lock-icon">🔒</div>
+        <h1>Setting up secure connection</h1>
+        <p>We're configuring SSL/TLS for</p>
+        <p class="domain">{{.Domain}}</p>
+        <div class="progress"><div class="progress-bar"></div></div>
+        <p>This typically takes 30-60 seconds.</p>
+        <p style="font-size: 14px; color: #999;">This page will refresh automatically</p>
+    </div>
+</body>
+</html>`))
+
+	failedTemplate = template.Must(template.New("failed").Parse(`<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Configuration Required</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            background: #f5f5f5;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 0;
+            padding: 20px;
+        }
+        .container {
+            background: white;
+            border-radius: 12px;
+            box-shadow: 0 4px 20px rgba(0,0,0,0.1);
+            padding: 40px;
+            max-width: 600px;
+            width: 100%;
+        }
+        h1 { color: #d93025; margin: 0 0 20px; font-size: 28px; }
+        .domain {
+            color: #333;
+            font-weight: 600;
+            background: #f8f9fa;
+            padding: 8px 12px;
+            border-radius: 6px;
+            display: inline-block;
+            margin: 10px 0;
+        }
+        .error-box {
+            background: #fef2f2;
+            border: 1px solid #fecaca;
+            border-radius: 8px;
+            padding: 16px;
+            margin: 20px 0;
+        }
+        .error-message {
+            color: #b91c1c;
+            font-family: 'Courier New', monospace;
+            font-size: 14px;
+            word-break: break-all;
+        }
+        h3 { color: #333; margin: 30px 0 15px; }
+        ul { color: #666; line-height: 1.8; }
+        li { margin: 8px 0; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>⚠️ Domain Configuration Required</h1>
+        <p>Unable to set up SSL/TLS certificate for:</p>
+        <div class="domain">{{.Domain}}</div>
+        <div class="error-box">
+            <strong>Error Details:</strong>
+            <div class="error-message">{{.Error}}</div>
+        </div>
+        <h3>Common causes:</h3>
+        <ul>
+            <li>DNS records not properly configured</li>
+            <li>Domain not pointing to our servers</li>
+            <li>CAA records blocking Let's Encrypt</li>
+            <li>Rate limits exceeded</li>
+        </ul>
+        <p>Please verify your DNS settings and contact support if the issue persists.</p>
+    </div>
+</body>
+</html>`))
+)
+
+const defaultNotFoundHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>404 - Domain Not Found</title>
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            background: #f5f5f5;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            margin: 0;
+        }
+        .container { text-align: center; }
+        h1 { font-size: 120px; color: #e0e0e0; margin: 0; font-weight: 700; }
+        h2 { color: #333; margin: 20px 0; font-size: 28px; }
+        p { color: #666; font-size: 18px; }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>404</h1>
+        <h2>Domain Not Found</h2>
+        <p>The requested domain is not configured on this server.</p>
+    </div>
+</body>
+</html>`
+
+// buildProvisioningHTML generates the provisioning status page using precompiled template.
+func buildProvisioningHTML(info *DomainInfo) string {
+	var buf strings.Builder
+	if err := provisioningTemplate.Execute(&buf, info); err != nil {
+		// Fallback to a simple error page if template execution fails
+		return "<!DOCTYPE html><html><body><h1>Error rendering page</h1></body></html>"
+	}
+	return buf.String()
+}
+
+// buildFailedHTML generates the failed status page using precompiled template.
+func buildFailedHTML(info *DomainInfo) string {
+	var buf strings.Builder
+	if err := failedTemplate.Execute(&buf, info); err != nil {
+		// Fallback to a simple error page if template execution fails
+		return "<!DOCTYPE html><html><body><h1>Error rendering page</h1></body></html>"
+	}
+	return buf.String()
+}


### PR DESCRIPTION
## Summary

This PR refactors the server and autocert infrastructure to improve lifecycle management, enhance concurrency for certificate operations, and provide better integration with errgroup-based application patterns.

### Key Changes

**Server Lifecycle Management**
- Split server operations into `Start()` (blocking) and `Stop()` (graceful shutdown) methods
- Added `Run()` method that returns an errgroup-compatible function for coordinated lifecycle management
- Improved context cancellation handling to return `context.Err()` from `Start()` for clearer error semantics
- Both `Server` and `AutoCertServer` now support consistent lifecycle patterns

**Certificate Management Concurrency**
- Replaced global mutex with per-domain locking in Let's Encrypt manager to allow concurrent operations on different domains
- Certificate generation, renewal, and deletion can now proceed in parallel for different domains
- Added maximum backoff cap (30s) to prevent excessive retry delays
- Improved error handling with dedicated `ErrDeleteFailed` error type

**Code Quality Improvements**
- Enhanced domain validation in host policy with explicit checks for edge cases (empty domains, consecutive dots, leading/trailing dots)
- Extracted HTML templates to dedicated `templates.go` file for better maintainability
- Added constants for ACME metadata markers (`acmeAccountKeyMarker`, `acmeMetadataMarker`)
- Improved test coverage to reflect new lifecycle semantics (context cancellation is now expected behavior)
- Removed obsolete test for cache deletion failure during renewal (atomic overwrites make this case irrelevant)

### Breaking Changes

**Method Signature Changes**
- `Server.Run()` signature changed from `func(context.Context, http.Handler) error` to `func(context.Context, http.Handler) func() error`
- `Server.Shutdown()` renamed to `Server.Stop()` and no longer requires context parameter
- `AutoCertServer.Run()` follows same pattern as `Server.Run()`
- `AutoCertServer.Shutdown()` renamed to `AutoCertServer.Stop()`

**Migration Guide**
```go
// Old pattern
ctx := context.Background()
server := server.New(":8080")
if err := server.Run(ctx, handler); err != nil {
    log.Fatal(err)
}

// New pattern - Option 1: Direct start/stop
ctx := context.Background()
server := server.New(":8080")
if err := server.Start(ctx, handler); err != nil {
    log.Fatal(err)
}
// Later: server.Stop()

// New pattern - Option 2: errgroup integration
g, ctx := errgroup.WithContext(context.Background())
server := server.New(":8080")
g.Go(server.Run(ctx, handler))
if err := g.Wait(); err != nil {
    log.Fatal(err)
}
```

### Test Plan

- [x] All existing tests updated and passing with new lifecycle semantics
- [x] Verified context cancellation returns appropriate errors
- [x] Confirmed per-domain locking allows concurrent certificate operations
- [x] Validated graceful shutdown behavior for both Server and AutoCertServer
- [x] Tested errgroup compatibility pattern
- [x] Verified double-run protection still works correctly

### Performance Impact

**Positive**
- Certificate operations for different domains can now run concurrently (previously blocked by global mutex)
- Reduced contention in multi-tenant scenarios where multiple domains need certificate management simultaneously

**Neutral**
- No significant performance impact on single-domain deployments
- Shutdown timeout behavior unchanged (still 30s default)